### PR TITLE
Fix bug on listing all locations

### DIFF
--- a/hpriser
+++ b/hpriser
@@ -123,12 +123,12 @@ done <<< "$locations_json"
 
 debug "Location codes to be cheked [" "${locations[@]}" "]"
 
-if [ ${#locations[@]} -eq 0 ]; then
-    error "No location specified"
-fi
-
 if $list_locations; then
     exit
+fi
+
+if [ ${#locations[@]} -eq 0 ]; then
+    error "No location specified"
 fi
 
 printf "| %-20s\t| %s | %-10s |\n" "LOCATION" "AVG PRICE" "M^2 (COUNT)"


### PR DESCRIPTION
Fix the bug reported on issue #9 

**How to test it?** 
List all locations by using the `-A` parameter
```shell
./hpriser -A
```
Other commands should succeed as well. 


